### PR TITLE
Fix typo on SQL Server's readme.md file

### DIFF
--- a/mssqlserver/readme.md
+++ b/mssqlserver/readme.md
@@ -10,4 +10,4 @@ Microsoft markets at least a dozen different editions of Microsoft SQL Server, a
 
 ## Credits 
 Developed by [Eduardo Gonçalves](https://twitter.com/eduardofg87), I am also on [Telegram](https://t.me/eduardofg87).
-[PostgreSQL on Wikipedia](https://en.wikipedia.org/wiki/Microsoft_SQL_Server)
+[Microsoft SQL Server on Wikipedia](https://en.wikipedia.org/wiki/Microsoft_SQL_Server)


### PR DESCRIPTION
There was a typo on SQL Server's readme.md file where it was written `PostgreSQL` instead of `Microsoft SQL Server`.